### PR TITLE
Add Better Instructions for Installing from Source to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Version 1.0.0 will mark the first stable release.
 > available on the package index yet.
 > For now, the package can only be built from source.
 
+linearmoney requires Python >= 3.12
 
 From PyPi:
 
@@ -65,8 +66,16 @@ From source:
 ```bash
 git clone https://github.com/GrammAcc/linearmoney
 cd linearmoney
-poetry shell
-poetry install
+poetry build
+```
+
+See the [poetry installation](https://python-poetry.org/docs/#installation) docs if
+you don't have poetry installed yet.
+
+Then to install (virtual environment recommended):
+
+```bash
+pip install path/to/cloned/repo
 ```
 
 ## Basic Usage


### PR DESCRIPTION
The instructions for installing from source in the README were originally written with the assumption that the user would be building as part of a contributor workflow, but the README should give instructions for how to build and install from source as a user of the library, so I have updated the installation section of the README with new instructions for how to build the package with poetry and then install with pip instead of using the poetry shell and install commands, which are good for contributing to the project but not useful for installing the library as a dependency in another project.