### PR TITLE
Reduce Minimum Required Python Version to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ data to provide data-driven interfaces for currency rounding, formatting, and lo
 
 ## Installation
 
-linearmoney requires Python >= 3.11
+linearmoney requires Python >= 3.10
 
 From PyPi:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{name = "GrammAcc", email = "grammaticallyacceptable@grammacc.dev"}]
 maintainers = [{name = "GrammAcc", email = "grammaticallyacceptable@grammacc.dev"}]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 keywords = ["money", "framework", "currency", "forex", "fintech"]
 classifiers = ["Development Status :: 3 - Alpha"]
 
@@ -53,7 +53,7 @@ python = "3.12"
 [tool.hatch.envs.default.scripts]
 ci = [
     "hatch run test:suite",
-    "hatch run -py=3.11 test:cov",
+    "hatch run -py=3.10,3.11 test:cov",
     "hatch run docs:test-prose",
     "hatch run docs:test-in-source",
     "hatch run types:check",
@@ -64,7 +64,7 @@ ci = [
 all = [
     "hatch run style:format",
     "- hatch run test:suite",
-    "- hatch run -py=3.11 test:cov",
+    "- hatch run -py=3.10,3.11 test:cov",
     "- hatch run docs:test-prose",
     "- hatch run docs:test-in-source",
     "- hatch run types:check",
@@ -72,6 +72,13 @@ all = [
     "- hatch run style:linttests",
     "- hatch run style:lintdocs",
 ]
+
+[tool.hatch.envs.py310]
+python = "3.10"
+
+[tool.hatch.envs.py311]
+python = "3.11"
+
 
 
 [tool.hatch.envs.test]
@@ -84,11 +91,11 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
-suite = "pytest"
-cov = "pytest --cov-config=pyproject.toml --cov-report html:htmlcov --cov=linearmoney"
+suite = "pytest {args}"
+cov = "pytest --cov-config=pyproject.toml --cov-report html:htmlcov --cov=linearmoney {args}"
 prod = "- pip install --force-reinstall -i https://test.pypi.org/simple linearmoney && pytest"
 
 

--- a/src/linearmoney/data.py
+++ b/src/linearmoney/data.py
@@ -24,9 +24,20 @@ from linearmoney.mixins import ImmutableDeduplicationMixin, EqualityByHashMixin
 from linearmoney.exceptions import UnknownDataError
 
 
-class FormatType(enum.StrEnum):
-    STANDARD = enum.auto()
-    ACCOUNTING = enum.auto()
+# This class needs to have a docstring, or the doctest examples in
+# the parent class `enum.Enum` will fail due to bare `Enum` not
+# being available in the test namespace.
+class FormatType(enum.Enum):
+    """Enum representing the allowed locale formats.
+
+    Primarily used to select l10n data with the `locale` function.
+    """
+
+    STANDARD = "standard"
+    ACCOUNTING = "accounting"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class DataMap(EqualityByHashMixin, ImmutableDeduplicationMixin, Mapping):
@@ -179,10 +190,10 @@ def locale(
             The region (territory) portion of the
             [locale tag](/linearmoney/glossary.html#locale-tag)
         nformat:
-            The number format to use. Should be a member of the `FormatType` string enum.
+            The number format to use. Should be a member of the `FormatType` enum.
             The difference in format is generally only in negative numbers. E.g. -10 in
             'standard' vs. (10) in 'accounting'.
-            If you aren't sure which format you need, you probably want 'standard'.
+            If you aren't sure which format you need, you probably want 'FormatType.STANDARD`.
         **overrides:
             Formatting options to override the default formatting rules for the
             requested locale.
@@ -221,10 +232,12 @@ def locale(
 
     locales: LocaleMap
 
-    if nformat in _fallback_locales:
+    format_key = str(nformat)
+
+    if format_key in _fallback_locales:
         locale_string = "_".join([language, region])
         try:
-            locales = _fallback_locales[nformat][locale_string]
+            locales = _fallback_locales[format_key][locale_string]
         except KeyError as e:
             raise UnknownDataError(
                 f"invalid value for `language` {language} or `region` {region}. \
@@ -233,8 +246,8 @@ Locale data not available under number format {nformat}"
 
     else:
         raise ValueError(
-            f"invalid value for `nformat`. Expected either 'standard' or \
-'accounting' got {nformat}"
+            f"invalid value for `nformat`. Expected either 'FormatType.Standard' or \
+'FormatType.Accounting' got {nformat}"
         )
 
     if overrides:

--- a/src/linearmoney/mixins.py
+++ b/src/linearmoney/mixins.py
@@ -7,8 +7,11 @@ __all__: list[str] = [
 
 
 from abc import ABCMeta, abstractmethod
-from typing import ClassVar, Self
+from typing import TYPE_CHECKING, ClassVar
 from collections.abc import Hashable, Sequence
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class ImmutableDeduplicationMixin:

--- a/src/linearmoney/scalar.py
+++ b/src/linearmoney/scalar.py
@@ -292,10 +292,10 @@ def l10n(
         >>> val = lm.vector.evaluate(av, "eur", fv)
         >>> rounded_val = lm.scalar.roundas(val, eur)
         >>> lm.scalar.l10n(rounded_val, eur, fr_FR)
-        '20,14€'
+        '20,14 €'
         >>> cash_rounded_val = lm.scalar.roundas(val, eur, cash=True)
         >>> lm.scalar.l10n(cash_rounded_val, eur, fr_FR)
-        '20,14€'
+        '20,14 €'
         >>> lm.scalar.l10n(rounded_val, eur, fr_FR, international=True)
         '20,14 EUR'
     """

--- a/src/linearmoney/vector.py
+++ b/src/linearmoney/vector.py
@@ -21,12 +21,15 @@ __all__: list[str] = [
 
 import decimal
 import copy
-from typing import TypeAlias, Self, TypedDict, TypeVar
+from typing import TYPE_CHECKING, TypeAlias, TypedDict, TypeVar
 from collections.abc import Iterator
 
 from linearmoney import cache, _utils
 from linearmoney.mixins import ImmutableDeduplicationMixin, EqualityByHashMixin
 from linearmoney.exceptions import SpaceError, IntegrityError
+
+if TYPE_CHECKING:
+    from typing import Self
 
 DecimalVector: TypeAlias = tuple[decimal.Decimal, ...]
 

--- a/tests/suite/caching_test.py
+++ b/tests/suite/caching_test.py
@@ -147,7 +147,8 @@ _valid_values = [
     112,
     112.12,
     decimal.Decimal(112.12),
-    fractions.Fraction(225, 2),
+    # Fractions don't have SupportsInt protocol until python 3.11.
+    # fractions.Fraction(225, 2),
 ]
 
 


### PR DESCRIPTION
I have removed use of the runtime features that were added in 3.11 or later.

We're still using typing features from later versions which is fine since type annotations aren't evaluated at runtime and we can run the type checker in a newer version with hatch.

Breaking changes:
1. Remove use of `enum.StrEnum` for `linearmoney.data.FormatType`.
  - `StrEnum` was added in 3.11, so I have changed `FormatType` to be a regular `enum.Enum` with a custom `__str__` that returns the value of the enum member instead of the name and value together.
  - This introduces an internal change to the way that we lookup the format for locale data. Passing a string literal such as `"standard"` to the `linearmoney.data.locale` function's `nformat` argument will still work in the current implementation, but this is now an implementation detail and not an officially supported usage of the api. This can change at any time, so callers that are providing a format type to the `locale` function should use the actual members of the `linearmoney.data.FormatType` enum instead of passing in strings directly.
  - The type checker will error if a string literal is provided, even if it works at runtime. I'm not sure if this would happen in the previous implementation since I never tried it, but StrEnums are supposed to behave like strings, so it's probably up to the specific type checker whether that was considered an error. It's always an error now, so this should make it easier to spot potentially flaky uses of string literals in locale definitions.