### PR TITLE
Add Optional SQLAlchemy Integrations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-extend-ignore = E203
+extend-ignore = E203, E701
 max-line-length = 100

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Key Features:
 - No dependencies other than Python itself.
 - Completely thread-safe.
 - 100% Test and API Documentation coverage.
+- Database/ORM integrations.
 
 The linearmoney library takes a non-traditional approach to financial applications
 by using linear algebra internally to ensure the correctness of monetary calculations
@@ -106,6 +107,24 @@ the code more explicit and easier to test.
 See the [Recipes](https://grammacc.github.io/linearmoney/recipes.html)
 section of the user guide for
 some examples of how to mitigate the verbosity of the library and other helpful patterns.
+
+## Optional Extensions
+
+The `linearmoney.ext` sub-package provides optional integrations with other libraries/tools.
+
+Most tools shouldn't need any kind of adapter layer for you to use linearmoney with
+them since you would normally evaluate a money vector whenever you need to do something
+with its value outside of linearmoney's functions or math between vectors. The exceptions
+to this are ORMs and similar tools that need some kind of serialization step to be
+performed.
+
+[SQLAlchemy](https://grammacc.github.io/linearmoney/api_reference/linearmoney/ext/sqlalchemy.html)
+integrations are implemented, and Django ORM is planned.
+
+If there is a tool that you want better integration with or simply some kind of
+extra functionality that requires additional dependencies, please
+[open an issue](https://github.com/GrammAcc/linearmoney/issues/new/choose) and
+we will evaluate if it is within the scope of the project to support as an extension.
 
 ## Contributing
 

--- a/documentation/run_doctests.py
+++ b/documentation/run_doctests.py
@@ -58,7 +58,7 @@ def _run_module_doctests(module: pdoc.doc.Module):
 
 # Mostly copied from pdoc.pdoc() implementation:
 all_modules: list[pdoc.doc.Module] = []
-for module_name in pdoc.extract.walk_specs(["linearmoney"]):
+for module_name in pdoc.extract.walk_specs(["linearmoney", "linearmoney.ext"]):
     try:
         all_modules.append(pdoc.doc.Module.from_name(module_name))
     except RuntimeError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ python = ["3.10", "3.11", "3.12"]
 suite = "pytest {args}"
 cov = "pytest --cov-config=pyproject.toml --cov-report html:htmlcov --cov=linearmoney {args}"
 prod = "- pip install --force-reinstall -i https://test.pypi.org/simple linearmoney && pytest"
+ext = "pytest tests/ext {args}"
 
 
 [tool.hatch.envs.types]
@@ -138,6 +139,7 @@ dependencies = [
     "mkdocs-material",
     "pytest",
 ]
+features = ["sqlalchemy"]
 
 [tool.hatch.envs.docs.scripts]
 build = [
@@ -156,25 +158,6 @@ detached = true
 [tool.hatch.envs.cldr.scripts]
 build = "python process_cldr_data.py"
 test = "python tests/cldr/check_data.py"
-
-[tool.hatch.envs.extest]
-description = "Test the optional extensions"
-dependencies = [
-    "pytest",
-    "pytest-cov",
-    "pytest-parametrize-cases",
-    "pytest-lazy-fixtures",
-    "pytest-asyncio",
-    "aiosqlite",
-]
-features = ["sqlalchemy"]
-
-[[tool.hatch.envs.extest.matrix]]
-python = ["3.10", "3.11", "3.12"]
-
-[tool.hatch.envs.extest.scripts]
-suite = "pytest tests/ext {args}"
-prod = "- pip install --force-reinstall -i https://test.pypi.org/simple linearmoney && pytest test/ext"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dependencies = [
     "pytest-lazy-fixtures",
     "pytest-asyncio",
     "aiosqlite",
+    "sqlalchemy[asyncio]",
 ]
 features = ["sqlalchemy"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "pytest-parametrize-cases",
     "pytest-lazy-fixtures",
 ]
+sqlalchemy = ["sqlalchemy"]
+
 
 [tool.hatch.version]
 path = "src/linearmoney/__init__.py"
@@ -34,7 +36,6 @@ path = "src/linearmoney/__init__.py"
 [tool.hatch.build]
 ignore-vcs = true
 include = ["*.json", "py.typed"]
-
 
 # This is needed for hatchling to find the version in the package __init__.py file.
 # See https://github.com/pypa/hatch/issues/981#issuecomment-1743631364
@@ -80,7 +81,6 @@ python = "3.10"
 python = "3.11"
 
 
-
 [tool.hatch.envs.test]
 description = "Test Suite and Coverage Reporting"
 dependencies = [
@@ -88,7 +88,10 @@ dependencies = [
     "pytest-cov",
     "pytest-parametrize-cases",
     "pytest-lazy-fixtures",
+    "pytest-asyncio",
+    "aiosqlite",
 ]
+features = ["sqlalchemy"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11", "3.12"]
@@ -119,7 +122,7 @@ dependencies = [
 [tool.hatch.envs.style.scripts]
 format = "black ."
 lintsrc = "flake8 src"
-linttests = "flake8 --extend-ignore E501 tests"
+linttests = "flake8 tests"
 lintdocs = "flake8 documentation"
 
 
@@ -150,11 +153,31 @@ detached = true
 build = "python process_cldr_data.py"
 test = "python tests/cldr/check_data.py"
 
+[tool.hatch.envs.extest]
+description = "Test the optional extensions"
+dependencies = [
+    "pytest",
+    "pytest-cov",
+    "pytest-parametrize-cases",
+    "pytest-lazy-fixtures",
+    "pytest-asyncio",
+    "aiosqlite",
+]
+features = ["sqlalchemy"]
+
+[[tool.hatch.envs.extest.matrix]]
+python = ["3.10", "3.11", "3.12"]
+
+[tool.hatch.envs.extest.scripts]
+suite = "pytest tests/ext {args}"
+prod = "- pip install --force-reinstall -i https://test.pypi.org/simple linearmoney && pytest test/ext"
+
 
 [tool.pytest.ini_options]
 log_file="testsuite.log"
 log_file_level="DEBUG"
 addopts = "--import-mode=importlib --show-capture=no --ignore=cldr-json"
+asyncio_mode = "auto"
 
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ all = [
     "- hatch run style:linttests",
     "- hatch run style:lintdocs",
 ]
+quicktest = "hatch run -py=3.10,3.11 test:suite {args}"
 
 [tool.hatch.envs.py310]
 python = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,10 @@ prod = "- pip install --force-reinstall -i https://test.pypi.org/simple linearmo
 
 [tool.hatch.envs.types]
 description = "Run static type checker"
-dependencies = ["mypy"]
+dependencies = [
+    "mypy",
+    "sqlalchemy[mypy]",
+]
 
 [tool.hatch.envs.types.scripts]
 check = "mypy -p linearmoney"

--- a/src/linearmoney/__init__.py
+++ b/src/linearmoney/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "resources",
     "mixins",
     "cache",
+    "ext",
 ]
 
 

--- a/src/linearmoney/ext/__init__.py
+++ b/src/linearmoney/ext/__init__.py
@@ -1,0 +1,9 @@
+"""Optional extensions to the linearmoney library.
+
+While the main library has no dependencies, submodules in this package may have
+their own dependencies which are defined as optional extras for linearmoney.
+
+See the documention for each individual submodule for the exact install commands.
+"""
+
+__all__ = ["sqlalchemy"]

--- a/src/linearmoney/ext/sqlalchemy.py
+++ b/src/linearmoney/ext/sqlalchemy.py
@@ -28,20 +28,18 @@ class VectorMoney(TypeDecorator):
     monetary values of the vectors.
 
     Examples:
-        >>> from sqlalchemy.orm import (
-        >>>     Mapped,
-        >>>     mapped_column,
-        >>>     DeclarativeBase,
-        >>> )
+        >>> from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase
         >>>
         >>> from linearmoney.ext.sqlalchemy import VectorMoney
         >>>
-        >>> class LMExample(DeclarativeBase):
+        >>> class BaseModel(DeclarativeBase): ...
         >>>
-        >>>     __tablename__ = "lm_example"
-        >>>
-        >>>     id: Mapped[int] = mapped_column(primary_key=True)
-        >>>     money_column: Mapped[VectorMoney] = mapped_column(VectorMoney)
+        >>> class LMExample(BaseModel):
+        ...
+        ...     __tablename__ = "lm_example"
+        ...
+        ...     id: Mapped[int] = mapped_column(primary_key=True)
+        ...     money_column: Mapped[VectorMoney] = mapped_column(VectorMoney)
     """
 
     impl = String
@@ -96,23 +94,21 @@ class AtomicMoney(TypeDecorator):
     instead.
 
     Examples:
-        >>> from sqlalchemy.orm import (
-        >>>     Mapped,
-        >>>     mapped_column,
-        >>>     DeclarativeBase,
-        >>> )
+        >>> from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase
         >>>
-        >>> import lienarmoney as lm
+        >>> import linearmoney as lm
         >>> from linearmoney.ext.sqlalchemy import AtomicMoney
+        >>>
+        >>> class BaseModel(DeclarativeBase): ...
         >>>
         >>> CURRENCY = lm.data.currency("USD")
         >>>
-        >>> class LMExample(DeclarativeBase):
-        >>>
-        >>>     __tablename__ = "lm_example"
-        >>>
-        >>>     id: Mapped[int] = mapped_column(primary_key=True)
-        >>>     money_column: Mapped[AtomicMoney] = mapped_column(AtomicMoney(CURRENCY))
+        >>> class LMExample(BaseModel):
+        ...
+        ...     __tablename__ = "lm_example"
+        ...
+        ...     id: Mapped[int] = mapped_column(primary_key=True)
+        ...     money_column: Mapped[AtomicMoney] = mapped_column(AtomicMoney(CURRENCY))
     """
 
     impl = Integer

--- a/src/linearmoney/ext/sqlalchemy.py
+++ b/src/linearmoney/ext/sqlalchemy.py
@@ -40,10 +40,18 @@ class VectorMoney(TypeDecorator):
     impl = String
     cache_ok = True
 
-    def process_bind_param(self, value: lm.vector.MoneyVector, dialect: Dialect):
+    # SQLAlchemy types `value` argument as Any | None, which makes sense for an overload.
+    # We ignore the override error because violating Liskov doesn't make any difference
+    # when the argument isn't typed.
+    def process_bind_param(
+        self, value: lm.vector.MoneyVector, dialect: Dialect  # type: ignore[override]
+    ):
         return lm.vector.store(value)
 
-    def process_result_value(self, value: String, dialect: Dialect):
+    # SQLAlchemy types `value` argument as Any | None, which makes sense for an overload.
+    # We ignore the override error because violating Liskov doesn't make any difference
+    # when the argument isn't typed.
+    def process_result_value(self, value: str, dialect: Dialect):  # type: ignore[override]
         return lm.vector.restore(value)
 
 
@@ -97,13 +105,21 @@ class AtomicMoney(TypeDecorator):
         self.forex = lm.vector.forex({"base": currency.iso_code, "rates": {}})
         self.space = lm.vector.space(self.forex)
 
-    def process_bind_param(self, value: lm.vector.MoneyVector, dialect: Dialect):
+    # SQLAlchemy types `value` argument as Any | None, which makes sense for an overload.
+    # We ignore the override error because violating Liskov doesn't make any difference
+    # when the argument isn't typed.
+    def process_bind_param(
+        self, value: lm.vector.MoneyVector, dialect: Dialect  # type: ignore[override]
+    ):
         return lm.scalar.atomic(
             lm.vector.evaluate(value, self.currency.iso_code, self.forex),
             self.currency,
         )
 
-    def process_result_value(self, value: Integer, dialect: Dialect):
+    # SQLAlchemy types `value` argument as Any | None, which makes sense for an overload.
+    # We ignore the override error because violating Liskov doesn't make any difference
+    # when the argument isn't typed.
+    def process_result_value(self, value: int, dialect: Dialect):  # type: ignore[override]
         exponent = decimal.Decimal(10) ** decimal.Decimal(self.currency.data["places"])
         decimal_value = decimal.Decimal(value) / exponent
         return lm.vector.asset(decimal_value, self.currency.iso_code, self.space)

--- a/src/linearmoney/ext/sqlalchemy.py
+++ b/src/linearmoney/ext/sqlalchemy.py
@@ -1,0 +1,109 @@
+"""SQLAlchemy ORM integrations for linearmoney."""
+
+import decimal
+
+from sqlalchemy.types import TypeDecorator, String, Integer
+from sqlalchemy import Dialect
+
+import linearmoney as lm
+
+
+class VectorMoney(TypeDecorator):
+    """SQLAlchemy column type that automatically serializes and
+    deserializes a `linearmoney.vector.MoneyVector` to and from a String column
+    for storage in the db.
+
+    This type preserves all vector information including the currency space, so
+    it should be used whenever non-destructive storage is desired.
+
+    The disadvantage of this column type is that it uses a sqlalchemy String column
+    (VARCHAR) underneath, so in-db aggregate functions like SUM and MAX/MIN cannot
+    be used and these operations need to be performed in Python if they are needed.
+
+    Examples:
+        >>> from sqlalchemy.orm import (
+        >>>     Mapped,
+        >>>     mapped_column,
+        >>>     DeclarativeBase,
+        >>> )
+        >>>
+        >>> from linearmoney.ext.sqlalchemy import VectorMoney
+        >>>
+        >>> class LMExample(DeclarativeBase):
+        >>>
+        >>>     __tablename__ = "lm_example"
+        >>>
+        >>>     id: Mapped[int] = mapped_column(primary_key=True)
+        >>>     money_column: Mapped[VectorMoney] = mapped_column(VectorMoney)
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value: lm.vector.MoneyVector, dialect: Dialect):
+        return lm.vector.store(value)
+
+    def process_result_value(self, value: String, dialect: Dialect):
+        return lm.vector.restore(value)
+
+
+class AtomicMoney(TypeDecorator):
+    """SQLAlchemy column type that automatically serializes and
+    deserializes a `linearmoney.vector.MoneyVector` as an atomic value in the smallest
+    denomination of `currency` to and from an integer column for storage in the db.
+
+    This type is intended to be used with single-currency applications. It
+    evaluates the stored asset vector in a single-currency space defined by
+    the `currency` argument provided on column declaration.
+
+    This means that attempting to store a money vector from a different currency space
+    will result in a `linearmoney.Exceptions.SpaceError`.
+
+    The advantage of this column type is that it allows the use of in-db aggregate
+    functions like SUM and MAX/MIN. The disadvantage is that it can only be used
+    with single-currency applications or with a manual conversion step before
+    passing any values into sqlalchemy's column operations. For this reason,
+    multi-currency applications should generally choose `VectorMoney` instead.
+
+    Examples:
+        >>> from sqlalchemy.orm import (
+        >>>     Mapped,
+        >>>     mapped_column,
+        >>>     DeclarativeBase,
+        >>> )
+        >>>
+        >>> import lienarmoney as lm
+        >>> from linearmoney.ext.sqlalchemy import AtomicMoney
+        >>>
+        >>> CURRENCY = lm.data.currency("USD")
+        >>> class LMExample(DeclarativeBase):
+        >>>
+        >>>     __tablename__ = "lm_example"
+        >>>
+        >>>     id: Mapped[int] = mapped_column(primary_key=True)
+        >>>     money_column: Mapped[AtomicMoney] = mapped_column(AtomicMoney(CURRENCY))
+    """
+
+    impl = Integer
+    cache_ok = True
+
+    currency: lm.data.CurrencyData
+    forex: lm.vector.ForexVector
+    space: lm.vector.CurrencySpace
+
+    def __init__(self, currency: lm.data.CurrencyData, *args, **kwargs) -> None:
+        super().__init__()
+        self.currency = currency
+        self.forex = lm.vector.forex({"base": currency.iso_code, "rates": {}})
+        self.space = lm.vector.space(self.forex)
+
+    def process_bind_param(self, value: lm.vector.MoneyVector, dialect: Dialect):
+        return lm.scalar.atomic(
+            lm.vector.evaluate(value, self.currency.iso_code, self.forex),
+            self.currency,
+        )
+
+    def process_result_value(self, value: Integer, dialect: Dialect):
+        exponent = decimal.Decimal(10) ** decimal.Decimal(self.currency.data["places"])
+        decimal_value = decimal.Decimal(value) / exponent
+        return lm.vector.asset(decimal_value, self.currency.iso_code, self.space)

--- a/src/linearmoney/vector.py
+++ b/src/linearmoney/vector.py
@@ -207,7 +207,7 @@ class MoneyVector(ImmutableDeduplicationMixin, EqualityByHashMixin):
     @property
     @cache.cached()
     def dim(self) -> int:
-        """The dimension of this `MunnyVector`."""
+        """The dimension of this `MoneyVector`."""
 
         return len(self)
 
@@ -215,7 +215,7 @@ class MoneyVector(ImmutableDeduplicationMixin, EqualityByHashMixin):
     @cache.cached()
     def axes(self) -> tuple[str, ...]:
         """Tuple of the ISO 4217 alpha currency codes representing the axes of this
-        `MunnyVector`."""
+        `MoneyVector`."""
 
         return self._axes
 

--- a/tests/ext/sqlalchemy_test.py
+++ b/tests/ext/sqlalchemy_test.py
@@ -1,0 +1,178 @@
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+    sessionmaker,
+)
+from sqlalchemy import create_engine, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import pytest
+
+
+import linearmoney as lm
+from linearmoney.ext.sqlalchemy import VectorMoney, AtomicMoney
+
+
+class BaseModel(DeclarativeBase): ...
+
+
+class VectorModel(BaseModel):
+
+    __tablename__ = "vector_model"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    money_column: Mapped[VectorMoney] = mapped_column(VectorMoney)
+
+
+class AtomicModel(BaseModel):
+
+    __tablename__ = "atomic_model"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    money_column: Mapped[AtomicMoney] = mapped_column(
+        AtomicMoney(lm.data.currency("USD"))
+    )
+
+
+@pytest.fixture
+def fixt_session():
+    """A sync Session with a fresh in-memory sqlite db."""
+
+    _engine = create_engine("sqlite:///:memory:", echo=False)
+    BaseModel.metadata.create_all(bind=_engine)
+    return sessionmaker(bind=_engine)
+
+
+@pytest.fixture
+async def fixt_async_session():
+    """An async Session with a fresh in-memory sqlite db."""
+
+    _async_engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with _async_engine.begin() as conn:
+        await conn.run_sync(BaseModel.metadata.create_all)
+    return async_sessionmaker(bind=_async_engine, expire_on_commit=False)
+
+
+def test_vector_money_read_write(fixt_session):
+    """Ensure the VectorMoney column type serializes to the db correctly."""
+
+    fo = lm.vector.forex({"base": "usd", "rates": {"jpy": 100}})
+    sp = lm.vector.space(fo)
+    asset_vec = lm.vector.asset(10, "usd", sp) + lm.vector.asset(100, "jpy", sp)
+    assert lm.vector.evaluate(asset_vec, "usd", fo) == 11
+
+    with fixt_session() as session:
+        session.add(VectorModel(id=1, money_column=asset_vec))
+        session.commit()
+        stored_asset_vec = (
+            session.execute(select(VectorModel).where(VectorModel.id == 1))
+            .scalars()
+            .first()
+            .money_column
+        )
+        assert stored_asset_vec == asset_vec
+
+
+async def test_vector_money_async_read_write(fixt_async_session):
+    """Ensure the VectorMoney column type serializes to the db correctly in async sqlalchemy."""
+
+    fo = lm.vector.forex({"base": "usd", "rates": {"jpy": 100}})
+    sp = lm.vector.space(fo)
+    asset_vec = lm.vector.asset(10, "usd", sp) + lm.vector.asset(100, "jpy", sp)
+    assert lm.vector.evaluate(asset_vec, "usd", fo) == 11
+
+    async with fixt_async_session() as session:
+        session.add(VectorModel(id=1, money_column=asset_vec))
+        await session.commit()
+        stored_asset_vec = (
+            (await session.execute(select(VectorModel).where(VectorModel.id == 1)))
+            .scalars()
+            .first()
+            .money_column
+        )
+        assert stored_asset_vec == asset_vec
+
+
+def test_vector_money_used_in_where_clause(fixt_session):
+    """Ensure the VectorMoney column type allows using money vectors in where clauses."""
+
+    fo = lm.vector.forex({"base": "usd", "rates": {"jpy": 100}})
+    sp = lm.vector.space(fo)
+    asset_vec = lm.vector.asset(10, "usd", sp) + lm.vector.asset(100, "jpy", sp)
+    assert lm.vector.evaluate(asset_vec, "usd", fo) == 11
+
+    with fixt_session() as session:
+        session.add(VectorModel(id=1, money_column=asset_vec))
+        session.commit()
+        stored_asset_vec = (
+            session.execute(
+                select(VectorModel).where(VectorModel.money_column == asset_vec)
+            )
+            .scalars()
+            .first()
+            .money_column
+        )
+        assert stored_asset_vec == asset_vec
+
+
+def test_atomic_money_read_write(fixt_session):
+    """Ensure the AtomicMoney column type serializes to the db correctly."""
+
+    fo = lm.vector.forex({"base": "usd", "rates": {}})
+    sp = lm.vector.space(fo)
+    asset_vec = lm.vector.asset(10, "usd", sp)
+    assert lm.vector.evaluate(asset_vec, "usd", fo) == 10
+
+    with fixt_session() as session:
+        session.add(VectorModel(id=1, money_column=asset_vec))
+        session.commit()
+        stored_asset_vec = (
+            session.execute(select(VectorModel).where(VectorModel.id == 1))
+            .scalars()
+            .first()
+            .money_column
+        )
+        assert stored_asset_vec == asset_vec
+
+
+async def test_atomic_money_async_read_write(fixt_async_session):
+    """Ensure the AtomicMoney column type serializes to the db correctly in async sqlalchemy."""
+
+    fo = lm.vector.forex({"base": "usd", "rates": {}})
+    sp = lm.vector.space(fo)
+    asset_vec = lm.vector.asset(10, "usd", sp)
+    assert lm.vector.evaluate(asset_vec, "usd", fo) == 10
+
+    async with fixt_async_session() as session:
+        session.add(VectorModel(id=1, money_column=asset_vec))
+        await session.commit()
+        stored_asset_vec = (
+            (await session.execute(select(VectorModel).where(VectorModel.id == 1)))
+            .scalars()
+            .first()
+            .money_column
+        )
+        assert stored_asset_vec == asset_vec
+
+
+def test_atomic_money_in_where_clause(fixt_session):
+    """Ensure the AtomicMoney column type allows using money vectors in where clauses."""
+
+    fo = lm.vector.forex({"base": "usd", "rates": {}})
+    sp = lm.vector.space(fo)
+    asset_vec = lm.vector.asset(10, "usd", sp)
+    assert lm.vector.evaluate(asset_vec, "usd", fo) == 10
+
+    with fixt_session() as session:
+        session.add(VectorModel(id=1, money_column=asset_vec))
+        session.commit()
+        stored_asset_vec = (
+            session.execute(
+                select(VectorModel).where(VectorModel.money_column == asset_vec)
+            )
+            .scalars()
+            .first()
+            .money_column
+        )
+        assert stored_asset_vec == asset_vec


### PR DESCRIPTION
This PR adds a new `linearmoney.ext` sub-package that contains the `sqlalchemy` module for integrations with the SQLAlchemy ORM.

There are two column types added:
- VectorMoney
- AtomicMoney

The difference is that VectorMoney stores the MoneyVector as a serialized string to preserve all information including the currency space, and AtomicMoney stores the MoneyVector as an integer representing its atomic value in the currency specified on column declaration.

Both do implicit serialization of the vectors to a primitive type, and both are non-destructive, but AtomicMoney will error if provided a vector in a currency space with more than one dimension or that doesn't match the currency it was declared with. This prevents accidental data corruption when writing to the db.

See the docstrings for these two classes for more details.

This PR also adds some minor changes in the pyproject.toml file. While developing on this feature, I found that having a way to quickly run the test suite on only one python version and specify arguments to the test command were useful, so I've added `{args}` to the test commands and also a new `quicktest` command in the default environment that runs the `test:suite` command with only the latest interpreter version instead of the full matrix. I also added environments `py310` and `py311`, which simply define a different interpreter version from the default environment that uses 3.12. This is useful for exploratory testing/debugging since we can quickly start a shell using a different interpreter version with hatch without having to make the binary available in the current shell under a different name such as `python3.10`.

Close #22 